### PR TITLE
Merge createRef docs into 16.3 release blog

### DIFF
--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -11,6 +11,12 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences
 
+### Reactathon 2018
+March 20-22 in San Francisco, USA
+
+[Website](https://www.reactathon.com/) [Twitter](https://twitter.com/reactathon)
+
+
 ### React Native Camp UA 2018
 March 31 in Kiev, Ukraine
 

--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -41,6 +41,11 @@ August 16-17 in Salt Lake City, Utah USA
 
 [Website](http://www.reactrally.com) - [Twitter](https://twitter.com/reactrally)
 
+### React Native EU 2018
+September 5-6 in Wrocław, Poland
+
+[Website](https://react-native.eu) - [Twitter](https://twitter.com/react_native_eu) - [Facebook](https://www.facebook.com/reactnativeeu)
+
 ### ReactNext 2018
 September 6 in Tel Aviv, Israel
 

--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -11,6 +11,11 @@ Do you know of a local React.js conference? Add it here! (Please keep the list c
 
 ## Upcoming Conferences
 
+### ReactFest 2018
+March 8-9 in London, UK
+
+[Website](https://reactfest.uk/) [Twitter](https://twitter.com/ReactFest) 
+
 ### Reactathon 2018
 March 20-22 in San Francisco, USA
 

--- a/content/community/examples.md
+++ b/content/community/examples.md
@@ -19,3 +19,4 @@ There are many example projects created by the React community. Feel free to add
 * **[Product Comparison Page](https://github.com/Rhymond/product-compare-react)** Simple Product Compare page built in React
 * **[Hacker News Clone React/GraphQL](https://github.com/clintonwoo/hackernews-react-graphql)** Hacker News clone rewritten with universal JavaScript, using React and GraphQL.
 * **[Bitcoin Price Index](https://github.com/mrkjlchvz/bitcoin-price-index)** Simple bitcoin price index data from CoinDesk API.
+* **[Builder Book](https://github.com/builderbook/builderbook)** Open source web app to write and host documentation or sell books. Built with React, Material-UI, Next, Express, Mongoose, MongoDB.

--- a/content/community/podcasts.md
+++ b/content/community/podcasts.md
@@ -16,6 +16,8 @@ Podcasts dedicated to React and individual podcast episodes with React discussio
 
 - [React 30](https://react30.com/) - A 30-minute podcast all about React (moved to [The React Podcast](http://reactpodcast.com)).
 
+- [React Native Radio](https://devchat.tv/react-native-radio)
+
 ## Episodes
 
 - [CodeWinds Episode 4](http://codewinds.com/podcast/004.html) - Pete Hunt talks with Jeff Barczewski about React.

--- a/content/community/tools-starter-kits.md
+++ b/content/community/tools-starter-kits.md
@@ -7,7 +7,7 @@ permalink: community/starter-kits.html
 
 ## Recommended by the React Team
 
-* **[Create React App](https://github.com/facebookincubator/create-react-app)** - An officially supported way to start a client-side React project with no configuration
+* **[Create React App](https://github.com/facebook/create-react-app)** - An officially supported way to start a client-side React project with no configuration
 * **[Next.js](https://learnnextjs.com/)** - Framework for server-rendered or statically-exported React apps
 * **[Gatsby](https://www.gatsbyjs.org/)** - Blazing-fast static site generator for React
 * **[nwb](https://github.com/insin/nwb)** - A toolkit for React apps, libraries and other npm modules for the web

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -24,7 +24,7 @@ If you want your application to be stable, don't use context. It is an experimen
 
 If you aren't familiar with state management libraries like [Redux](https://github.com/reactjs/redux) or [MobX](https://github.com/mobxjs/mobx), don't use context. For many practical applications, these libraries and their React bindings are a good choice for managing state that is relevant to many components. It is far more likely that Redux is the right solution to your problem than that context is the right solution.
 
-If you aren't an experienced React developer, don't use context. There is usually a better way to implement functionality just using props and state.
+If you're still learning React, don't use context. There is usually a better way to implement functionality just using props and state.
 
 If you insist on using context despite these warnings, try to isolate your use of context to a small area and avoid using the context API directly when possible so that it's easier to upgrade when the API changes.
 

--- a/content/docs/design-principles.md
+++ b/content/docs/design-principles.md
@@ -33,7 +33,7 @@ For example, if React didn't provide support for local state or lifecycle hooks,
 
 This is why sometimes we add features to React itself. If we notice that many components implement a certain feature in incompatible or inefficient ways, we might prefer to bake it into React. We don't do it lightly. When we do it, it's because we are confident that raising the abstraction level benefits the whole ecosystem. State, lifecycle hooks, cross-browser event normalization are good examples of this.
 
-We always discuss such improvement proposals with the community. You can find some of those discussions by the ["big picture"](https://github.com/facebook/react/issues?q=is:open+is:issue+label:"big+picture") label on the React issue tracker.
+We always discuss such improvement proposals with the community. You can find some of those discussions by the ["big picture"](https://github.com/facebook/react/issues?q=is:open+is:issue+label:"Type:+Big+Picture") label on the React issue tracker.
 
 ### Escape Hatches
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -186,7 +186,7 @@ If you "fork" props by using them for state, you might also want to implement [`
 componentWillMount()
 ```
 
-`componentWillMount()` is invoked immediately before mounting occurs. It is called before `render()`, therefore calling `setState()` synchronously in this method will not trigger an extra rendering. Generally, we recommend using the `constructor()` instead.
+`componentWillMount()` is invoked just before mounting occurs. It is called before `render()`, therefore calling `setState()` synchronously in this method will not trigger an extra rendering. Generally, we recommend using the `constructor()` instead.
 
 Avoid introducing any side-effects or subscriptions in this method. For those use cases, use `componentDidMount()` instead.
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -248,7 +248,7 @@ We do not recommend doing deep equality checks or using `JSON.stringify()` in `s
 componentWillUpdate(nextProps, nextState)
 ```
 
-`componentWillUpdate()` is invoked immediately before rendering when new props or state are being received. Use this as an opportunity to perform preparation before an update occurs. This method is not called for the initial render.
+`componentWillUpdate()` is invoked just before rendering when new props or state are being received. Use this as an opportunity to perform preparation before an update occurs. This method is not called for the initial render.
 
 Note that you cannot call `this.setState()` here; nor should you do anything else (e.g. dispatch a Redux action) that would trigger an update to a React component before `componentWillUpdate()` returns.
 

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -69,7 +69,7 @@ If you call [`ReactDOM.hydrate()`](/docs/react-dom.html#hydrate) on a node that 
 >
 > Server-only. This API is not available in the browser.
 >
-> The stream returned from this method will return a byte stream encoded in utf-8. If you need a stream in another encoding, take a look a project like [iconv-lite](https://www.npmjs.com/package/iconv-lite), which provides transform streams for transcoding text.
+> The stream returned from this method will return a byte stream encoded in utf-8. If you need a stream in another encoding, take a look at a project like [iconv-lite](https://www.npmjs.com/package/iconv-lite), which provides transform streams for transcoding text.
 
 * * *
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -267,16 +267,23 @@ All things considered, we advise against exposing DOM nodes whenever possible, b
 
 React also supports another way to set refs called "callback refs", which give more fine-grain control over when refs are set and unset.
 
-Instead of passing a `ref` attribute created by `createRef()`, you pass a function. The function receives the React component instance or HTML DOM element as its argument, which can be stored and accessed elsewhere. This example uses the `ref` callback to store a reference to a DOM node:
+Instead of passing a `ref` attribute created by `createRef()`, you pass a function. The function receives the React component instance or HTML DOM element as its argument, which can be stored and accessed elsewhere. 
+
+The example below implements a common pattern: using the `ref` callback to store a reference to a DOM node in an instance property.
 
 ```javascript{6,17}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
+    this.textInput = { value: null }; // initial placeholder for the ref
     this.focusTextInput = () => {
-      // Explicitly focus the text input using the raw DOM API
-      this.textInput.focus();
+      // Focus the text input using the raw DOM API
+      this.textInput.value.focus();
     };
+  }
+
+  componentDidMount () {
+    if (this.textInput) this.focusTextInput() // autofocus the input on mount
   }
 
   render() {
@@ -286,7 +293,7 @@ class CustomTextInput extends React.Component {
       <div>
         <input
           type="text"
-          ref={(input) => { this.textInput = input; }} />
+          ref={element => this.textInput.value = element} />
         <input
           type="button"
           value="Focus the text input"
@@ -299,8 +306,6 @@ class CustomTextInput extends React.Component {
 ```
 
 React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts. `ref` callbacks are invoked before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
-
-Using the `ref` callback to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
 You can pass callback refs between components like you can with object refs that were created with `React.createRef()`.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -261,7 +261,7 @@ class Grandparent extends React.Component {
 
 Here, the ref `this.inputElement` is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed ref as a `ref` attribute to the `<input>`. As a result, `this.inputElement.value` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
-All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
+When possible, we advise against exposing DOM nodes, but it can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
 
 ### Callback Refs
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -37,8 +37,7 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 >
 >The examples below have updated to use the `React.createRef()` API introduced in React 16.3.
 
-
-Refs can be created using `React.createRef()` and are commonly assigned to an instance property when a component is constructed.
+Refs can be created using `React.createRef()` and attached to React elements via the `ref` attribute. Refs are commonly assigned to an instance property when a component is constructed so they can be referenced throughout the the component.
 
 ```javascript{4,7}
 class MyComponent extends React.Component {
@@ -51,8 +50,6 @@ class MyComponent extends React.Component {
   }
 }
 ```
-
-Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
 
 When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -265,7 +265,7 @@ All things considered, we advise against exposing DOM nodes whenever possible, b
 
 ### Callback Refs
 
-React also supports another way to set refs called "callback refs", which give more fine-grain control over when refs are set and unset.
+React also supports another way to set refs called "callback refs", which gives more fine-grain control over when refs are set and unset.
 
 Instead of passing a `ref` attribute created by `createRef()`, you pass a function. The function receives the React component instance or HTML DOM element as its argument, which can be stored and accessed elsewhere. 
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -94,12 +94,13 @@ React will assign the `value` property with the DOM element when the component m
 
 When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
-```javascript{4,12}
+```javascript{4,7,12}
 class AutoFocusTextInput extends React.Component {
   constructor(props) {
     super(props);
     this.textInput = React.createRef();
   }
+
   componentDidMount() {
     this.textInput.value.focusTextInput();
   }
@@ -124,7 +125,7 @@ class CustomTextInput extends React.Component {
 
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```javascript{1,8,12}
+```javascript{1,8,13}
 function MyFunctionalComponent() {
   return <input />;
 }
@@ -167,7 +168,7 @@ function CustomTextInput(props) {
         onClick={handleClick}
       />
     </div>
-  );  
+  );
 }
 ```
 
@@ -211,7 +212,7 @@ This works even though `CustomTextInput` is a functional component. Unlike the s
 
 Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
 
-```javascript{4,12,21,25}
+```javascript{4,12,20,24}
 function CustomTextInput(props) {
   return (
     <div>
@@ -227,7 +228,6 @@ function Parent(props) {
     </div>
   );
 }
-
 
 class Grandparent extends React.Component {
   constructor(props) {

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -11,6 +11,8 @@ redirect_from:
 permalink: docs/refs-and-the-dom.html
 ---
 
+Refs provide a way to access DOM nodes and React elements created by React by getting a _reference_ to the element in the render method.
+
 In the typical React dataflow, [props](/docs/components-and-props.html) are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
 
 ### When to Use Refs

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -33,22 +33,10 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 
 >**Note:**
 >
->The examples below have updated to use the new `React.createRef()` API, introduced in React 16.3.
+>The examples below have updated to use the `React.createRef()` API introduced in React 16.3.
 
 
-Refs can be created using `React.createRef()` and are commonly assigned to a component class instance in the constructor or via a property initializer.
-
-```javascript{4}
-class MyComponent extends React.Component {
-  constructor(props) {
-    super(props);
-    this.myRef = React.createRef();
-  }
-}
-```
-
-Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
-
+Refs can be created using `React.createRef()` and are commonly assigned to an instance property when a component is constructed.
 
 ```javascript{4,7}
 class MyComponent extends React.Component {
@@ -62,9 +50,11 @@ class MyComponent extends React.Component {
 }
 ```
 
+Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
+
 When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
 
-```javascript{5,11,21}
+```javascript{5,12,22}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
@@ -75,6 +65,7 @@ class CustomTextInput extends React.Component {
 
   focusTextInput() {
     // Explicitly focus the text input using the raw DOM API
+    // Note: we're accessing "value" to get the DOM node
     this.textInput.value.focus();
   }
 
@@ -257,20 +248,18 @@ All things considered, we advise against exposing DOM nodes whenever possible, b
 
 ### Callback Refs
 
-The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. Callback refs work in much the same way as object refs.
+React also supports another way to set refs called "callback refs", which give more fine-grain control over when refs are set and unset.
 
-With callback refs, instead of creating a ref with `React.createRef()`, you pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
+Instead of passing a `ref` attribute created by `createRef()`, you pass a function. The function receives the React component instance or HTML DOM element as its argument, which can be stored and accessed elsewhere. This example uses the `ref` callback to store a reference to a DOM node:
 
-```javascript{8,9,19}
+```javascript{6,17}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
-    this.focusTextInput = this.focusTextInput.bind(this);
-  }
-
-  focusTextInput() {
-    // Explicitly focus the text input using the raw DOM API
-    this.textInput.focus();
+    this.focusTextInput = () => {
+      // Explicitly focus the text input using the raw DOM API
+      this.textInput.focus();
+    };
   }
 
   render() {
@@ -294,7 +283,7 @@ class CustomTextInput extends React.Component {
 
 React will call the `ref` callback with the DOM element when the component mounts, and call it with `null` when it unmounts. `ref` callbacks are invoked before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
 
-Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
+Using the `ref` callback to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
 You can pass callback refs between components like you can with object refs that were created with `React.createRef()`.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -328,7 +328,11 @@ In the example above, `Parent` passes its ref callback as an `inputRef` prop to 
 
 ### Legacy API: String Refs
 
-If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
+If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. 
+
+> Note
+>
+> If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 
 ### Caveats with callback refs
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -111,7 +111,7 @@ React will assign the `value` property with the DOM element when the component m
 
 If we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting, we could use a ref to get access to the custom input and call its `focusTextInput` method manually:
 
-```javascript{4,7,12}
+```javascript{4,8,13}
 class AutoFocusTextInput extends React.Component {
   constructor(props) {
     super(props);

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -195,7 +195,7 @@ In rare cases, you might want to have access to a child's DOM node from a parent
 
 While you could [add a ref to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
 
-Instead, in such cases we recommend exposing a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and attach it to the DOM node as a `ref` attribute. This lets the parent pass its ref to the child's DOM node through the component in the middle.
+Instead, in such cases we recommend exposing a special prop on the child. This prop can be named anything other than ref (e.g. inputRef). The child component can then forward the prop to the DOM node as a ref attribute. This lets the parent pass its ref to the child's DOM node through the component in the middle.
 
 This works both for classes and for functional components.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -271,11 +271,17 @@ Instead of passing a `ref` attribute created by `createRef()`, you pass a functi
 
 The example below implements a common pattern: using the `ref` callback to store a reference to a DOM node in an instance property.
 
-```javascript{6,17}
+```javascript{5,7-9,11-14,19,29,34}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
+
     this.textInput = { value: null }; // initial placeholder for the ref
+
+    this.setTextInputRef = element => {
+      this.textInput.value = element
+    };
+
     this.focusTextInput = () => {
       // Focus the text input using the raw DOM API
       this.textInput.value.focus();
@@ -283,7 +289,8 @@ class CustomTextInput extends React.Component {
   }
 
   componentDidMount () {
-    if (this.textInput) this.focusTextInput() // autofocus the input on mount
+    // autofocus the input on mount
+    if (this.textInput.value) this.focusTextInput()
   }
 
   render() {
@@ -293,7 +300,8 @@ class CustomTextInput extends React.Component {
       <div>
         <input
           type="text"
-          ref={element => this.textInput.value = element} />
+          ref={this.setTextInputRef}
+        />
         <input
           type="button"
           value="Focus the text input"

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -11,7 +11,7 @@ redirect_from:
 permalink: docs/refs-and-the-dom.html
 ---
 
-Refs provide a way to access DOM nodes and React elements created by React by getting a _reference_ to the element in the render method.
+Refs provide a way to access DOM nodes or React elements created in the render method.
 
 In the typical React dataflow, [props](/docs/components-and-props.html) are the only way that parent components interact with their children. To modify a child, you re-render it with new props. However, there are a few cases where you need to imperatively modify a child outside of the typical dataflow. The child to be modified could be an instance of a React component, or it could be a DOM element. For both of these cases, React provides an escape hatch.
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -31,9 +31,211 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 
 ### Adding a Ref to a DOM Element
 
+>**Note:**
+>
+>The examples below have updated to use the new `React.createRef()` API, introduced in React 16.3.
+
+
 React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
 
-When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
+When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
+
+```javascript{8,9,19}
+class CustomTextInput extends React.Component {
+  constructor(props) {
+    super(props);
+    // create a ref to store the textInput DOM element
+    this.textInput = React.createRef();
+    this.focusTextInput = this.focusTextInput.bind(this);
+  }
+
+  focusTextInput() {
+    // Explicitly focus the text input using the raw DOM API
+    this.textInput.value.focus();
+  }
+
+  render() {
+    // tell React that we want the associate the <input> ref
+    // to the `textInput` that we created in the constructor
+    return (
+      <div>
+        <input
+          type="text"
+          ref={this.textInput} />
+        <input
+          type="button"
+          value="Focus the text input"
+          onClick={this.focusTextInput}
+        />
+      </div>
+    );
+  }
+}
+```
+
+React will assign the `value` property with the DOM element when the component mounts, and assign it back to `null` when it unmounts. `ref` updates happen before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
+
+### Adding a Ref to a Class Component
+
+When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
+
+```javascript{3,9}
+class AutoFocusTextInput extends React.Component {
+  constructor(props) {
+    super(props);
+    this.textInput = React.createRef();
+  }
+  componentDidMount() {
+    this.textInput.value.focusTextInput();
+  }
+
+  render() {
+    return (
+      <CustomTextInput ref={this.textInput} />
+    );
+  }
+}
+```
+
+Note that this only works if `CustomTextInput` is declared as a class:
+
+```js{1}
+class CustomTextInput extends React.Component {
+  // ...
+}
+```
+
+### Refs and Functional Components
+
+**You may not use the `ref` attribute on functional components** because they don't have instances:
+
+```javascript{1,7}
+function MyFunctionalComponent() {
+  return <input />;
+}
+
+class Parent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.textInput = React.createRef();
+  }
+  render() {
+    // This will *not* work!
+    return (
+      <MyFunctionalComponent ref={this.textInput} />
+    );
+  }
+}
+```
+
+You should convert the component to a class if you need a ref to it, just like you do when you need lifecycle methods or state.
+
+You can, however, **use the `ref` attribute inside a functional component** as long as you refer to a DOM element or a class component:
+
+```javascript{2,3,6,13}
+function CustomTextInput(props) {
+  // textInput must be declared here so the ref can refer to it
+  let textInput = React.createRef();
+
+  function handleClick() {
+    textInput.value.focus();
+  }
+
+  return (
+    <div>
+      <input
+        type="text"
+        ref={textInput} />
+      <input
+        type="button"
+        value="Focus the text input"
+        onClick={handleClick}
+      />
+    </div>
+  );  
+}
+```
+
+### Exposing DOM Refs to Parent Components
+
+In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
+
+While you could [add a ref to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
+
+Instead, in such cases we recommend exposing a special prop on the child. The child would take a prop with an arbitrary name (e.g. `inputRef`) and attach it to the DOM node as a `ref` attribute. This lets the parent pass its ref to the child's DOM node through the component in the middle.
+
+This works both for classes and for functional components.
+
+```javascript{4,13}
+function CustomTextInput(props) {
+  return (
+    <div>
+      <input ref={props.inputRef} />
+    </div>
+  );
+}
+
+class Parent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputElement = React.createRef();
+  }
+  render() {
+    return (
+      <CustomTextInput inputRef={this.inputElement} />
+    );
+  }
+}
+```
+
+In the example above, `Parent` passes its class property `this.inputElement` as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same ref as a special `ref` attribute to the `<input>`. As a result, `this.inputElement.value` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+
+Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
+
+This works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can [only be specified for DOM elements and for class components](#refs-and-functional-components), there are no restrictions on regular component props like `inputRef`.
+
+Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
+
+```javascript{4,12,22}
+function CustomTextInput(props) {
+  return (
+    <div>
+      <input ref={props.inputRef} />
+    </div>
+  );
+}
+
+function Parent(props) {
+  return (
+    <div>
+      My input: <CustomTextInput inputRef={props.inputRef} />
+    </div>
+  );
+}
+
+
+class Grandparent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.inputElement = React.createRef();
+  }
+  render() {
+    return (
+      <Parent inputRef={this.inputElement} />
+    );
+  }
+}
+```
+
+Here, the ref `this.inputElement` is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed ref as a `ref` attribute to the `<input>`. As a result, `this.inputElement.value` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
+
+All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
+
+### Callback Refs
+
+The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. In much the same way object refs work, callback refs can be used in a similar approach.
+
+With callback refs, instead of creating a ref with `React.createRef()`, you instead pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
 
 ```javascript{8,9,19}
 class CustomTextInput extends React.Component {
@@ -70,90 +272,7 @@ React will call the `ref` callback with the DOM element when the component mount
 
 Using the `ref` callback just to set a property on the class is a common pattern for accessing DOM elements. The preferred way is to set the property in the `ref` callback like in the above example. There is even a shorter way to write it: `ref={input => this.textInput = input}`. 
 
-### Adding a Ref to a Class Component
-
-When the `ref` attribute is used on a custom component declared as a class, the `ref` callback receives the mounted instance of the component as its argument. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
-
-```javascript{3,9}
-class AutoFocusTextInput extends React.Component {
-  componentDidMount() {
-    this.textInput.focusTextInput();
-  }
-
-  render() {
-    return (
-      <CustomTextInput
-        ref={(input) => { this.textInput = input; }} />
-    );
-  }
-}
-```
-
-Note that this only works if `CustomTextInput` is declared as a class:
-
-```js{1}
-class CustomTextInput extends React.Component {
-  // ...
-}
-```
-
-### Refs and Functional Components
-
-**You may not use the `ref` attribute on functional components** because they don't have instances:
-
-```javascript{1,7}
-function MyFunctionalComponent() {
-  return <input />;
-}
-
-class Parent extends React.Component {
-  render() {
-    // This will *not* work!
-    return (
-      <MyFunctionalComponent
-        ref={(input) => { this.textInput = input; }} />
-    );
-  }
-}
-```
-
-You should convert the component to a class if you need a ref to it, just like you do when you need lifecycle methods or state.
-
-You can, however, **use the `ref` attribute inside a functional component** as long as you refer to a DOM element or a class component:
-
-```javascript{2,3,6,13}
-function CustomTextInput(props) {
-  // textInput must be declared here so the ref callback can refer to it
-  let textInput = null;
-
-  function handleClick() {
-    textInput.focus();
-  }
-
-  return (
-    <div>
-      <input
-        type="text"
-        ref={(input) => { textInput = input; }} />
-      <input
-        type="button"
-        value="Focus the text input"
-        onClick={handleClick}
-      />
-    </div>
-  );  
-}
-```
-
-### Exposing DOM Refs to Parent Components
-
-In rare cases, you might want to have access to a child's DOM node from a parent component. This is generally not recommended because it breaks component encapsulation, but it can occasionally be useful for triggering focus or measuring the size or position of a child DOM node.
-
-While you could [add a ref to the child component](#adding-a-ref-to-a-class-component), this is not an ideal solution, as you would only get a component instance rather than a DOM node. Additionally, this wouldn't work with functional components.
-
-Instead, in such cases we recommend exposing a special prop on the child. The child would take a function prop with an arbitrary name (e.g. `inputRef`) and attach it to the DOM node as a `ref` attribute. This lets the parent pass its ref callback to the child's DOM node through the component in the middle.
-
-This works both for classes and for functional components.
+You can pass callback refs between components like you can with object refs that were created with `React.createRef()`.
 
 ```javascript{4,13}
 function CustomTextInput(props) {
@@ -177,49 +296,10 @@ class Parent extends React.Component {
 
 In the example above, `Parent` passes its ref callback as an `inputRef` prop to the `CustomTextInput`, and the `CustomTextInput` passes the same function as a special `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Parent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
 
-Note that the name of the `inputRef` prop in the above example has no special meaning, as it is a regular component prop. However, using the `ref` attribute on the `<input>` itself is important, as it tells React to attach a ref to its DOM node.
-
-This works even though `CustomTextInput` is a functional component. Unlike the special `ref` attribute which can [only be specified for DOM elements and for class components](#refs-and-functional-components), there are no restrictions on regular component props like `inputRef`.
-
-Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
-
-```javascript{4,12,22}
-function CustomTextInput(props) {
-  return (
-    <div>
-      <input ref={props.inputRef} />
-    </div>
-  );
-}
-
-function Parent(props) {
-  return (
-    <div>
-      My input: <CustomTextInput inputRef={props.inputRef} />
-    </div>
-  );
-}
-
-
-class Grandparent extends React.Component {
-  render() {
-    return (
-      <Parent
-        inputRef={el => this.inputElement = el}
-      />
-    );
-  }
-}
-```
-
-Here, the ref callback is first specified by `Grandparent`. It is passed to the `Parent` as a regular prop called `inputRef`, and the `Parent` passes it to the `CustomTextInput` as a prop too. Finally, the `CustomTextInput` reads the `inputRef` prop and attaches the passed function as a `ref` attribute to the `<input>`. As a result, `this.inputElement` in `Grandparent` will be set to the DOM node corresponding to the `<input>` element in the `CustomTextInput`.
-
-All things considered, we advise against exposing DOM nodes whenever possible, but this can be a useful escape hatch. Note that this approach requires you to add some code to the child component. If you have absolutely no control over the child component implementation, your last option is to use [`findDOMNode()`](/docs/react-dom.html#finddomnode), but it is discouraged.
-
 ### Legacy API: String Refs
 
 If you worked with React before, you might be familiar with an older API where the `ref` attribute is a string, like `"textInput"`, and the DOM node is accessed as `this.refs.textInput`. We advise against it because string refs have [some issues](https://github.com/facebook/react/pull/8333#issuecomment-271648615), are considered legacy, and **are likely to be removed in one of the future releases**. If you're currently using `this.refs.textInput` to access refs, we recommend the callback pattern instead.
 
-### Caveats
+### Caveats with callback refs
 
 If the `ref` callback is defined as an inline function, it will get called twice during updates, first with `null` and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one. You can avoid this by defining the `ref` callback as a bound method on the class, but note that it shouldn't matter in most cases.

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -31,9 +31,9 @@ For example, instead of exposing `open()` and `close()` methods on a `Dialog` co
 
 Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/docs/lifting-state-up.html) guide for examples of this.
 
->**Note:**
+> Note
 >
->The examples below have updated to use the `React.createRef()` API introduced in React 16.3.
+> The examples below have been updated to use the React.createRef() API introduced in React 16.3. If you are using an earlier release of React, we recommend using [#callback-refs](callback refs) instead.
 
 ### Creating Refs
 
@@ -59,10 +59,10 @@ When a ref is passed to an element in `render`, a reference to the node becomes 
 const node = this.myRef.value
 ```
 
-The value of the ref differs depending on whether the node is an HTML DOM node, a React class component instance, or a stateless functional component:
+The value of the ref differs depending on the type of the node:
 
 - When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property.
-- When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`.
+- When the `ref` attribute is used on a custom class component, the `ref` object receives the mounted instance of the component as its `value`.
 - **You may not use the `ref` attribute on functional components** because they don't have instances.
 
 The examples below demonstrate the differences.

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -36,11 +36,35 @@ Your first inclination may be to use refs to "make things happen" in your app. I
 >The examples below have updated to use the new `React.createRef()` API, introduced in React 16.3.
 
 
-React supports a special attribute that you can attach to any component. The `ref` attribute takes a callback function, and the callback will be executed immediately after the component is mounted or unmounted.
+Refs can be created using `React.createRef()` and are commonly assigned to a component class instance in the constructor or via a property initializer.
+
+```javascript{4}
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.myRef = React.createRef();
+  }
+}
+```
+
+Refs can then be attached to React elements via the `ref` attribute by passing the property on the class instance as the value to that attribute.
+
+
+```javascript{4,7}
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.myRef = React.createRef();
+  }
+  render() {
+    return <div ref={this.myRef} />;
+  }
+}
+```
 
 When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
 
-```javascript{8,9,19}
+```javascript{5,11,21}
 class CustomTextInput extends React.Component {
   constructor(props) {
     super(props);
@@ -56,7 +80,7 @@ class CustomTextInput extends React.Component {
 
   render() {
     // tell React that we want the associate the <input> ref
-    // to the `textInput` that we created in the constructor
+    // with the `textInput` that we created in the constructor
     return (
       <div>
         <input
@@ -79,7 +103,7 @@ React will assign the `value` property with the DOM element when the component m
 
 When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
 
-```javascript{3,9}
+```javascript{4,12}
 class AutoFocusTextInput extends React.Component {
   constructor(props) {
     super(props);
@@ -109,7 +133,7 @@ class CustomTextInput extends React.Component {
 
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 
-```javascript{1,7}
+```javascript{1,8,12}
 function MyFunctionalComponent() {
   return <input />;
 }
@@ -166,7 +190,7 @@ Instead, in such cases we recommend exposing a special prop on the child. The ch
 
 This works both for classes and for functional components.
 
-```javascript{4,13}
+```javascript{4,12,16}
 function CustomTextInput(props) {
   return (
     <div>
@@ -196,7 +220,7 @@ This works even though `CustomTextInput` is a functional component. Unlike the s
 
 Another benefit of this pattern is that it works several components deep. For example, imagine `Parent` didn't need that DOM node, but a component that rendered `Parent` (let's call it `Grandparent`) needed access to it. Then we could let the `Grandparent` specify the `inputRef` prop to the `Parent`, and let `Parent` "forward" it to the `CustomTextInput`:
 
-```javascript{4,12,22}
+```javascript{4,12,21,25}
 function CustomTextInput(props) {
   return (
     <div>
@@ -233,9 +257,9 @@ All things considered, we advise against exposing DOM nodes whenever possible, b
 
 ### Callback Refs
 
-The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. In much the same way object refs work, callback refs can be used in a similar approach.
+The above examples use `React.createRef()`, which can be thought of as "object refs". React also supports an alternative approach called "callback refs", which offer the same functionality as object refs, but also also give more fine-grain control over when refs are set and unset. Callback refs work in much the same way as object refs.
 
-With callback refs, instead of creating a ref with `React.createRef()`, you instead pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
+With callback refs, instead of creating a ref with `React.createRef()`, you pass normal JavaScript functions to `ref` attributes. When the `ref` attribute is used on an HTML element, the `ref` callback receives the underlying DOM element as its argument. For example, this code uses the `ref` callback to store a reference to a DOM node:
 
 ```javascript{8,9,19}
 class CustomTextInput extends React.Component {

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -31,13 +31,13 @@ For example, instead of exposing `open()` and `close()` methods on a `Dialog` co
 
 Your first inclination may be to use refs to "make things happen" in your app. If this is the case, take a moment and think more critically about where state should be owned in the component hierarchy. Often, it becomes clear that the proper place to "own" that state is at a higher level in the hierarchy. See the [Lifting State Up](/docs/lifting-state-up.html) guide for examples of this.
 
-### Adding a Ref to a DOM Element
-
 >**Note:**
 >
 >The examples below have updated to use the `React.createRef()` API introduced in React 16.3.
 
-Refs can be created using `React.createRef()` and attached to React elements via the `ref` attribute. Refs are commonly assigned to an instance property when a component is constructed so they can be referenced throughout the the component.
+### Creating Refs
+
+Refs are created using `React.createRef()` and attached to React elements via the `ref` attribute. Refs are commonly assigned to an instance property when a component is constructed so they can be referenced throughout the the component.
 
 ```javascript{4,7}
 class MyComponent extends React.Component {
@@ -51,7 +51,25 @@ class MyComponent extends React.Component {
 }
 ```
 
-When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property. For example, this code uses a `ref` to store a reference to a DOM node:
+### Accessing Refs
+
+When a ref is passed to an element in `render`, a reference to the node becomes accessible at the `value` attribute of the ref.
+
+```javascript
+const node = this.myRef.value
+```
+
+The value of the ref differs depending on whether the node is an HTML DOM node, a React class component instance, or a stateless functional component:
+
+- When the `ref` attribute is used on an HTML element, the `ref` created in the constructor with `React.createRef()` receives the underlying DOM element as its `value` property.
+- When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`.
+- **You may not use the `ref` attribute on functional components** because they don't have instances.
+
+The examples below demonstrate the differences.
+
+#### Adding a Ref to a DOM Element
+
+This code uses a `ref` to store a reference to a DOM node:
 
 ```javascript{5,12,22}
 class CustomTextInput extends React.Component {
@@ -89,9 +107,9 @@ class CustomTextInput extends React.Component {
 
 React will assign the `value` property with the DOM element when the component mounts, and assign it back to `null` when it unmounts. `ref` updates happen before `componentDidMount` or `componentDidUpdate` lifecycle hooks.
 
-### Adding a Ref to a Class Component
+#### Adding a Ref to a Class Component
 
-When the `ref` attribute is used on a custom component declared as a class, the `ref` object receives the mounted instance of the component as its `value`. For example, if we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting:
+If we wanted to wrap the `CustomTextInput` above to simulate it being clicked immediately after mounting, we could use a ref to get access to the custom input and call its `focusTextInput` method manually:
 
 ```javascript{4,7,12}
 class AutoFocusTextInput extends React.Component {
@@ -120,7 +138,7 @@ class CustomTextInput extends React.Component {
 }
 ```
 
-### Refs and Functional Components
+#### Refs and Functional Components
 
 **You may not use the `ref` attribute on functional components** because they don't have instances:
 

--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -22,25 +22,23 @@ We will explain these steps below in detail.
 
 ### Adding Flow to a Project
 
-First, navigate to your project directory in the terminal. You will need to run two commands.
+First, navigate to your project directory in the terminal. You will need to run the following command:
 
 If you use [Yarn](https://yarnpkg.com/), run:
 
 ```bash
 yarn add --dev flow-bin
-yarn run flow init
 ```
 
 If you use [npm](https://www.npmjs.com/), run:
 
 ```bash
 npm install --save-dev flow-bin
-npm run flow init
 ```
 
-The first command installs the latest version of Flow into your project. The second command creates a Flow configuration file that you will need to commit.
+This command installs the latest version of Flow into your project.
 
-Finally, add `flow` to the `"scripts"` section of your `package.json`:
+Now, add `flow` to the `"scripts"` section of your `package.json` to be able to use this from the terminal:
 
 ```js{4}
 {
@@ -52,6 +50,22 @@ Finally, add `flow` to the `"scripts"` section of your `package.json`:
   // ...
 }
 ```
+
+Finally, run one of the following commands:
+
+If you use [Yarn](https://yarnpkg.com/), run:
+
+```bash
+yarn run flow init
+```
+
+If you use [npm](https://www.npmjs.com/), run:
+
+```bash
+npm run flow init
+```
+
+This command will create a Flow configuration file that you will need to commit.
 
 ### Stripping Flow Syntax from the Compiled Code
 


### PR DESCRIPTION
Merging `createRef` docs (reactjs/reactjs.org/pull/637) into the 16.3 blog post PR since they need to be released together.